### PR TITLE
Add missing JS parity functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,19 @@ The RPG example demonstrates:
 
 The player agent will automatically fight monsters and collect food based on its programmed goals and the current game state.
 
+## JavaScript Port
+
+This repository also contains a partial JavaScript port of the GOAP system under
+`rpg-goap-js/`.  The Node.js version mirrors the Python architecture and can be
+run using:
+
+```bash
+npm start --prefix rpg-goap-js
+```
+
+Tests for the JavaScript code can be executed with:
+
+```bash
+npm test --silent --prefix rpg-goap-js
+```
+

--- a/goap/__init__.py
+++ b/goap/__init__.py
@@ -1,0 +1,2 @@
+from goap_python.actions import Action
+from goap_python.agent import Agent

--- a/rpg-goap-js/PARITY_REQUIREMENTS.md
+++ b/rpg-goap-js/PARITY_REQUIREMENTS.md
@@ -1,0 +1,104 @@
+# JavaScript-Python Parity Requirements
+
+This document outlines the requirements for achieving full parity between the JavaScript and Python versions of the RPG GOAP example.
+
+## Current State
+
+### Python Version Behavior
+The Python version (`rpg_goap_python_example.example`) provides detailed console logging including:
+- Turn-by-turn progression (`--- Turn X ---`)
+- Agent action execution (`Player executing action: Go To Enemy`)
+- Movement details (`Player moving toward Monster 5 from Vector2(10, 10) to Vector2(10, 11)`)
+- Proximity events (`Player reached Monster 5!`)
+- Combat results (`Player attacked Monster 5. Monster 5 HP: 1`)
+- Agent deaths (`Monster 5 defeated! Agent Monster 5 has died.`)
+- Health tracking (`Player HP: 79`)
+- Food consumption (`Monster 2 ate food at Vector2(1, 11)`)
+- Game completion (`Game finished.`)
+
+### JavaScript Version Current Behavior
+The JavaScript version (`src/example.js`) currently:
+- Runs silently without console output
+- Uses canvas for visual rendering only
+- Executes GOAP logic correctly but provides no feedback
+- Terminates after 10 turns without indication
+
+## Required Changes for Full Parity
+
+### 1. Console Logging Implementation
+The JavaScript version needs to match the Python version's console output exactly:
+
+```javascript
+// Required logging patterns:
+console.log(`--- Turn ${turn} ---`);
+console.log(`${agent.name} executing action: ${action.name}`);
+console.log(`${agent.name} moving toward ${target.name} from ${startPos} to ${endPos}`);
+console.log(`${agent.name} reached ${target.name}!`);
+console.log(`${attacker.name} attacked ${target.name}. ${target.name} HP: ${hp}`);
+console.log(`${agent.name} defeated!`);
+console.log(`Agent ${agent.name} has died.`);
+console.log(`${agent.name} ate food at ${position}`);
+console.log("Game finished.");
+```
+
+### 2. Action Execution Hooks
+Implement detailed action logging by:
+- Using `Action.registerOnBeginExecute()` and `Action.registerOnFinishExecute()` hooks
+- Adding movement tracking in movement executors
+- Adding combat result logging in combat executors
+- Adding food consumption logging in eating executors
+
+### 3. Game State Tracking
+- Track agent health changes
+- Monitor agent deaths and remove from active agents list
+- Extend game duration to match Python version (30+ turns)
+- Implement proper game termination conditions
+
+### 4. Agent Behavior Details
+- Log detailed movement paths and destinations
+- Track proximity detection ("reached" events)
+- Report action precondition failures
+- Show goal priority switching
+
+## Fixed Issues
+
+### Import Error Resolution
+**Issue**: `ExecutionStatus` was incorrectly imported from `actions.js` instead of `goals.js`
+**Fix Applied**: Moved `ExecutionStatus` import to `goals.js` in `src/rpg/factories.js`
+
+### Setup Scripts
+**Added**: `setup.sh` and `run.sh` scripts for easier project setup and execution, matching the Python version's convenience scripts.
+
+## Testing Requirements
+
+The JavaScript version should produce output similar to this Python example:
+```
+--- Turn 1 ---
+Player executing action: Go To Enemy
+Player moving toward Monster 5 from Vector2(10, 10) to Vector2(10, 11)
+Player reached Monster 5!
+Monster 1 executing action: Go To Food
+Monster 2 executing action: Eat
+Monster 2 ate food at Vector2(1, 11)
+...
+```
+
+## Success Criteria
+
+- [ ] Console output matches Python version format
+- [ ] All agent actions are logged with details
+- [ ] Movement tracking shows start/end positions
+- [ ] Combat results show HP changes
+- [ ] Agent deaths are properly reported
+- [ ] Game runs for comparable duration
+- [ ] Food consumption is logged
+- [ ] Game termination is announced
+
+## Implementation Notes
+
+- Use existing action execution hooks rather than modifying core GOAP logic
+- Maintain visual canvas rendering alongside console logging
+- Preserve existing agent behavior and game mechanics
+- Follow JavaScript/Node.js console logging best practices
+
+This parity will ensure both versions provide identical user experience and debugging capabilities.

--- a/rpg-goap-js/package.json
+++ b/rpg-goap-js/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "rpg-goap-js",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test",
+    "start": "node ./src/example.js"
+  },
+  "dependencies": {
+    "canvas": "^2.11.2"
+  }
+}

--- a/rpg-goap-js/run.sh
+++ b/rpg-goap-js/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Run script for RPG GOAP JavaScript Example
+set -e
+
+echo "Running RPG GOAP JavaScript Example..."
+
+# Check if Node.js is installed
+if ! command -v node &> /dev/null; then
+    echo "Error: Node.js not found. Please run ./setup.sh first."
+    exit 1
+fi
+
+# Check if dependencies are installed
+if [ ! -d "node_modules" ]; then
+    echo "Dependencies not found. Running setup..."
+    ./setup.sh
+fi
+
+# Run the example with timeout
+timeout 10 npm start

--- a/rpg-goap-js/setup.sh
+++ b/rpg-goap-js/setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Setup script for RPG GOAP JavaScript
+set -e
+
+echo "Setting up RPG GOAP JavaScript..."
+
+# Check if Node.js is installed
+if ! command -v node &> /dev/null; then
+    echo "Error: Node.js not found. Please install Node.js first."
+    echo "Visit: https://nodejs.org/"
+    exit 1
+fi
+
+# Check if npm is installed
+if ! command -v npm &> /dev/null; then
+    echo "Error: npm not found. Please install npm first."
+    exit 1
+fi
+
+echo "Node.js version: $(node --version)"
+echo "npm version: $(npm --version)"
+
+# Install dependencies
+echo "Installing dependencies..."
+npm install
+
+echo "Setup complete!"
+echo ""
+echo "To run the RPG example:"
+echo "  ./run.sh"
+echo ""
+echo "To test the example:"
+echo "  timeout 10 npm start"
+echo ""
+echo "To run tests:"
+echo "  npm test"

--- a/rpg-goap-js/src/example.js
+++ b/rpg-goap-js/src/example.js
@@ -1,0 +1,79 @@
+import { createCanvas } from 'canvas';
+import { Agent } from './goap/agent.js';
+import { StepMode } from './goap/actions.js';
+import { PlayerFactory, RpgMonsterFactory } from './rpg/factories.js';
+import { Vector2, MaxX, MaxY } from './rpg/utils.js';
+
+// Minimal canvas-based example mirroring the Python version
+
+const CELL_SIZE = 20;
+const WIDTH = MaxX * CELL_SIZE;
+const HEIGHT = MaxY * CELL_SIZE;
+
+const canvas = createCanvas(WIDTH, HEIGHT);
+const ctx = canvas.getContext('2d');
+
+const agents = [];
+const foodPositions = [];
+
+function randomInt(max) {
+  return Math.floor(Math.random() * max);
+}
+
+for (let i = 0; i < 20; i++) {
+  foodPositions.push(new Vector2(randomInt(MaxX), randomInt(MaxY)));
+}
+
+const player = PlayerFactory.create(agents, foodPositions);
+agents.push(player);
+
+for (let i = 0; i < 5; i++) {
+  const m = RpgMonsterFactory.create(agents, foodPositions);
+  m.state.position = new Vector2(randomInt(MaxX), randomInt(MaxY));
+  agents.push(m);
+}
+
+let turn = 0;
+
+function step() {
+  turn += 1;
+  agents.forEach((a) => a.step(StepMode.OneAction));
+  draw();
+  if (turn < 10) setTimeout(step, 200);
+}
+
+function draw() {
+  ctx.fillStyle = 'black';
+  ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+  ctx.strokeStyle = 'white';
+  for (let x = 0; x <= WIDTH; x += CELL_SIZE) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, HEIGHT);
+    ctx.stroke();
+  }
+  for (let y = 0; y <= HEIGHT; y += CELL_SIZE) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(WIDTH, y);
+    ctx.stroke();
+  }
+
+  ctx.fillStyle = 'yellow';
+  for (const pos of foodPositions) {
+    ctx.fillRect(pos.x * CELL_SIZE + 2, pos.y * CELL_SIZE + 2, CELL_SIZE - 4, CELL_SIZE - 4);
+  }
+
+  for (const agent of agents) {
+    const pos = agent.state.position;
+    if (!(pos instanceof Vector2)) continue;
+    ctx.fillStyle = agent.state.faction === 'player' ? 'blue' : 'green';
+    ctx.fillRect(pos.x * CELL_SIZE + 2, pos.y * CELL_SIZE + 2, CELL_SIZE - 4, CELL_SIZE - 4);
+  }
+}
+
+step();
+
+export { canvas }; // For potential testing
+

--- a/rpg-goap-js/src/goap/actions.js
+++ b/rpg-goap-js/src/goap/actions.js
@@ -1,0 +1,238 @@
+import { DictionaryExtensionMethods } from './utils.js';
+import { ExecutionStatus, ComparisonOperator } from './goals.js';
+
+export const StepMode = Object.freeze({
+  Default: 1,
+  OneAction: 2,
+  AllActions: 3,
+});
+
+
+export class Action {
+  constructor({
+    name = null,
+    permutationSelectors = {},
+    executor = Action._defaultExecutor,
+    cost = 1.0,
+    costCallback = null,
+    preconditions = {},
+    comparativePreconditions = {},
+    postconditions = {},
+    arithmeticPostconditions = {},
+    parameterPostconditions = {},
+    stateMutator = null,
+    stateChecker = null,
+    stateCostDeltaMultiplier = Action.defaultStateCostDeltaMultiplier,
+  } = {}) {
+    this._permutationSelectors = { ...permutationSelectors };
+    this._executor = executor;
+    this.name = name ?? `Action ${Math.random()}`;
+    this._costBase = cost;
+    this._costCallback = costCallback ?? Action._defaultCostCallback;
+    this._preconditions = { ...preconditions };
+    this._comparativePreconditions = { ...comparativePreconditions };
+    this._postconditions = { ...postconditions };
+    this._arithmeticPostconditions = { ...arithmeticPostconditions };
+    this._parameterPostconditions = { ...parameterPostconditions };
+    this._stateMutator = stateMutator;
+    this._stateChecker = stateChecker;
+    this.stateCostDeltaMultiplier = stateCostDeltaMultiplier;
+    this._parameters = {};
+    this.executionStatus = ExecutionStatus.NotYetExecuted;
+  }
+
+  equals(other) {
+    return other instanceof Action && this.name === other.name;
+  }
+
+  copy() {
+    const a = new Action({
+      name: this.name,
+      permutationSelectors: this._permutationSelectors,
+      executor: this._executor,
+      cost: this._costBase,
+      costCallback: this._costCallback,
+      preconditions: DictionaryExtensionMethods.copyDict(this._preconditions),
+      comparativePreconditions: DictionaryExtensionMethods.copyDict(
+        this._comparativePreconditions
+      ),
+      postconditions: DictionaryExtensionMethods.copyDict(this._postconditions),
+      arithmeticPostconditions: DictionaryExtensionMethods.copyDict(
+        this._arithmeticPostconditions
+      ),
+      parameterPostconditions: DictionaryExtensionMethods.copyDict(
+        this._parameterPostconditions
+      ),
+      stateMutator: this._stateMutator,
+      stateChecker: this._stateChecker,
+      stateCostDeltaMultiplier: this.stateCostDeltaMultiplier,
+    });
+    a._parameters = DictionaryExtensionMethods.copyDict(this._parameters);
+    return a;
+  }
+
+  setParameter(key, value) {
+    this._parameters[key] = value;
+  }
+
+  getParameter(key) {
+    return this._parameters[key];
+  }
+
+  getCost(currentState) {
+    try {
+      return this._costCallback(this, currentState);
+    } catch {
+      return Infinity;
+    }
+  }
+
+  execute(agent) {
+    Action.onBeginExecute(agent, this, this._parameters);
+    if (this.isPossible(agent.state)) {
+      const status = this._executor(agent, this);
+      if (status === ExecutionStatus.Succeeded) {
+        this.applyEffects(agent.state);
+      }
+      this.executionStatus = status;
+      Action.onFinishExecute(agent, this, status, this._parameters);
+      return status;
+    }
+    this.executionStatus = ExecutionStatus.NotPossible;
+    Action.onFinishExecute(agent, this, this.executionStatus, this._parameters);
+    return this.executionStatus;
+  }
+
+  isPossible(state) {
+    for (const [key, value] of Object.entries(this._preconditions)) {
+      if (!(key in state)) return false;
+      const current = state[key];
+      if (current === null && value !== null) return false;
+      if (current !== null && current !== value) return false;
+    }
+    for (const [key, pair] of Object.entries(this._comparativePreconditions)) {
+      if (!(key in state)) return false;
+      const current = state[key];
+      const desired = pair.value;
+      const op = pair.operator;
+      if (op === ComparisonOperator.Undefined) return false;
+      if (op === ComparisonOperator.Equals) {
+        if (current !== desired) return false;
+      } else if (current == null || desired == null) {
+        return false;
+      } else if (op === ComparisonOperator.LessThan) {
+        if (!(current < desired)) return false;
+      } else if (op === ComparisonOperator.GreaterThan) {
+        if (!(current > desired)) return false;
+      } else if (op === ComparisonOperator.LessThanOrEquals) {
+        if (!(current <= desired)) return false;
+      } else if (op === ComparisonOperator.GreaterThanOrEquals) {
+        if (!(current >= desired)) return false;
+      }
+    }
+    if (this._stateChecker && !this._stateChecker(this, state)) return false;
+    return true;
+  }
+
+  getPermutations(state) {
+    if (Object.keys(this._permutationSelectors).length === 0) return [{}];
+    const outputs = {};
+    for (const [key, selector] of Object.entries(this._permutationSelectors)) {
+      const vals = selector(state);
+      if (!vals || vals.length === 0) return [];
+      outputs[key] = vals;
+    }
+    const params = Object.keys(outputs);
+    const counts = params.map((p) => outputs[p].length);
+    const indices = new Array(params.length).fill(0);
+    const results = [];
+    while (true) {
+      const out = {};
+      for (let i = 0; i < indices.length; i++) {
+        const param = params[i];
+        out[param] = outputs[param][indices[i]];
+      }
+      results.push(out);
+      if (Action._indicesAtMaximum(indices, counts)) break;
+      Action._incrementIndices(indices, counts);
+    }
+    return results;
+  }
+
+  applyEffects(state) {
+    for (const [key, value] of Object.entries(this._postconditions)) {
+      state[key] = value;
+    }
+    for (const [key, value] of Object.entries(this._arithmeticPostconditions)) {
+      if (!(key in state)) continue;
+      const current = state[key];
+      if (typeof current === 'number' && typeof value === 'number') {
+        state[key] = current + value;
+      }
+    }
+    for (const [paramKey, stateKey] of Object.entries(this._parameterPostconditions)) {
+      if (paramKey in this._parameters) {
+        state[stateKey] = this._parameters[paramKey];
+      }
+    }
+    if (this._stateMutator) this._stateMutator(this, state);
+  }
+
+  setParameters(params) {
+    this._parameters = params;
+  }
+
+  hashCode() {
+    let hash = 0;
+    const str = this.name ?? '';
+    for (let i = 0; i < str.length; i++) {
+      hash = ((hash << 5) - hash) + str.charCodeAt(i);
+      hash |= 0; // Convert to 32bit integer
+    }
+    return hash;
+  }
+
+  static _defaultExecutor(agent, action) {
+    return ExecutionStatus.Failed;
+  }
+
+  static _defaultCostCallback(action, state) {
+    return action._costBase;
+  }
+
+  static defaultStateCostDeltaMultiplier(action, key) {
+    return 1.0;
+  }
+
+  static _indicesAtMaximum(indices, counts) {
+    for (let i = 0; i < indices.length; i++) {
+      if (indices[i] < counts[i] - 1) return false;
+    }
+    return true;
+  }
+
+  static _incrementIndices(indices, counts) {
+    if (Action._indicesAtMaximum(indices, counts)) return;
+    for (let i = 0; i < indices.length; i++) {
+      if (indices[i] === counts[i] - 1) {
+        indices[i] = 0;
+      } else {
+        indices[i] += 1;
+        return;
+      }
+    }
+  }
+}
+
+Action._onBegin = [];
+Action._onFinish = [];
+
+Action.onBeginExecute = (agent, action, params) => {
+  for (const h of Action._onBegin) h(agent, action, params);
+};
+Action.onFinishExecute = (agent, action, status, params) => {
+  for (const h of Action._onFinish) h(agent, action, status, params);
+};
+
+Action.registerOnBeginExecute = (h) => { Action._onBegin.push(h); };
+Action.registerOnFinishExecute = (h) => { Action._onFinish.push(h); };

--- a/rpg-goap-js/src/goap/agent.js
+++ b/rpg-goap-js/src/goap/agent.js
@@ -1,0 +1,158 @@
+import { Planner } from './planning.js';
+import { StepMode } from './actions.js';
+import { ExecutionStatus } from './goals.js';
+
+export class Agent {
+  static _onAgentStep = [];
+  static _onActionSequenceCompleted = [];
+  static _onPlanningStarted = [];
+  static _onPlanningStartedForGoal = [];
+  static _onPlanningFinishedForGoal = [];
+  static _onPlanningFinished = [];
+  static _onPlanUpdated = [];
+  static _onEvaluatedActionNode = [];
+
+  constructor({
+    name = null,
+    state = {},
+    memory = {},
+    goals = [],
+    actions = [],
+    sensors = [],
+    costMaximum = Infinity,
+    stepMaximum = Infinity,
+  } = {}) {
+    this.name = name ?? `Agent`;
+    this.state = { ...state };
+    this.memory = { ...memory };
+    this.goals = goals.slice();
+    this.actions = actions.slice();
+    this.sensors = sensors.slice();
+    this.costMaximum = costMaximum;
+    this.stepMaximum = stepMaximum;
+    this.currentActionSequences = [];
+    this.isBusy = false;
+    this.isPlanning = false;
+  }
+
+  step(mode = StepMode.Default) {
+    Agent.onAgentStep(this);
+    for (const sensor of this.sensors) {
+      sensor.run(this);
+    }
+    if (mode === StepMode.Default) {
+      this._stepAsync();
+    } else if (mode === StepMode.OneAction) {
+      this._execute();
+    } else if (mode === StepMode.AllActions) {
+      while (this.isBusy) {
+        this._execute();
+      }
+    }
+  }
+
+  plan() {
+    if (!this.isBusy && !this.isPlanning) {
+      this.isPlanning = true;
+      Agent.onPlanningStarted(this);
+      Planner.plan(this, this.costMaximum, this.stepMaximum);
+    }
+  }
+
+  planAsync() {
+    if (!this.isBusy && !this.isPlanning) {
+      this.isPlanning = true;
+      Agent.onPlanningStarted(this);
+      setTimeout(() => {
+        Planner.plan(this, this.costMaximum, this.stepMaximum);
+      }, 0);
+    }
+  }
+
+  executePlan() {
+    if (!this.isPlanning) {
+      this._execute();
+    }
+  }
+
+  clearPlan() {
+    this.currentActionSequences.length = 0;
+  }
+
+  _stepAsync() {
+    if (!this.isBusy && !this.isPlanning) {
+      this.isPlanning = true;
+      Agent.onPlanningStarted(this);
+      Planner.plan(this, this.costMaximum, this.stepMaximum);
+    } else if (!this.isPlanning) {
+      this._execute();
+    }
+  }
+
+  _execute() {
+    if (this.currentActionSequences.length > 0) {
+      const toRemove = [];
+      for (const seq of this.currentActionSequences) {
+        if (seq.length > 0) {
+          const action = seq[0];
+          const status = action.execute(this);
+          if (status !== ExecutionStatus.Executing) {
+            seq.shift();
+          }
+          if (seq.length === 0) toRemove.push(seq);
+        } else {
+          toRemove.push(seq);
+        }
+      }
+      for (const s of toRemove) {
+        const idx = this.currentActionSequences.indexOf(s);
+        if (idx >= 0) this.currentActionSequences.splice(idx, 1);
+      }
+      if (this.currentActionSequences.length === 0) {
+        this.isBusy = false;
+        Agent._onActionSequenceCompleted.forEach((h) => h(this));
+      }
+    } else {
+      this.isBusy = false;
+    }
+  }
+}
+
+Agent.onAgentStep = (agent) => {
+  Agent._onAgentStep.forEach((h) => h(agent));
+};
+Agent.onActionSequenceCompleted = (agent) => {
+  Agent._onActionSequenceCompleted.forEach((h) => h(agent));
+};
+Agent.onPlanningStarted = (agent) => {
+  Agent._onPlanningStarted.forEach((h) => h(agent));
+};
+Agent.onPlanningStartedForGoal = (agent, goal) => {
+  Agent._onPlanningStartedForGoal.forEach((h) => h(agent, goal));
+};
+Agent.onPlanningFinishedForGoal = (agent, goal, util) => {
+  Agent._onPlanningFinishedForGoal.forEach((h) => h(agent, goal, util));
+};
+Agent.onPlanningFinished = (agent, goal, util) => {
+  Agent._onPlanningFinished.forEach((h) => h(agent, goal, util));
+};
+Agent.onPlanUpdated = (agent, actions) => {
+  Agent._onPlanUpdated.forEach((h) => h(agent, actions));
+};
+Agent.onEvaluatedActionNode = (node, map) => {
+  Agent._onEvaluatedActionNode.forEach((h) => h(node, map));
+};
+
+Agent.registerOnAgentStep = (h) => Agent._onAgentStep.push(h);
+Agent.registerOnActionSequenceCompleted = (h) =>
+  Agent._onActionSequenceCompleted.push(h);
+Agent.registerOnPlanningStarted = (h) => Agent._onPlanningStarted.push(h);
+Agent.registerOnPlanningStartedForGoal = (h) =>
+  Agent._onPlanningStartedForGoal.push(h);
+Agent.registerOnPlanningFinishedForGoal = (h) =>
+  Agent._onPlanningFinishedForGoal.push(h);
+Agent.registerOnPlanningFinished = (h) =>
+  Agent._onPlanningFinished.push(h);
+Agent.registerOnPlanUpdated = (h) => Agent._onPlanUpdated.push(h);
+Agent.registerOnEvaluatedActionNode = (h) =>
+  Agent._onEvaluatedActionNode.push(h);

--- a/rpg-goap-js/src/goap/goals.js
+++ b/rpg-goap-js/src/goap/goals.js
@@ -1,0 +1,51 @@
+export const ComparisonOperator = Object.freeze({
+  Undefined: 0,
+  Equals: 1,
+  LessThan: 2,
+  LessThanOrEquals: 3,
+  GreaterThan: 4,
+  GreaterThanOrEquals: 5,
+});
+
+export class ComparisonValuePair {
+  constructor(value = null, operator = ComparisonOperator.Undefined) {
+    this.value = value;
+    this.operator = operator;
+  }
+}
+
+export const ExecutionStatus = Object.freeze({
+  NotYetExecuted: 1,
+  Executing: 2,
+  Succeeded: 3,
+  Failed: 4,
+  NotPossible: 5,
+});
+
+export class BaseGoal {
+  constructor(name = null, weight = 1.0) {
+    this.name = name ?? `Goal ${Math.random()}`;
+    this.weight = weight;
+  }
+}
+
+export class Goal extends BaseGoal {
+  constructor(name = null, weight = 1.0, desiredState = {}) {
+    super(name, weight);
+    this.desiredState = { ...desiredState };
+  }
+}
+
+export class ExtremeGoal extends BaseGoal {
+  constructor(name = null, weight = 1.0, desiredState = {}) {
+    super(name, weight);
+    this.desiredState = { ...desiredState };
+  }
+}
+
+export class ComparativeGoal extends BaseGoal {
+  constructor(name = null, weight = 1.0, desiredState = {}) {
+    super(name, weight);
+    this.desiredState = { ...desiredState };
+  }
+}

--- a/rpg-goap-js/src/goap/planning.js
+++ b/rpg-goap-js/src/goap/planning.js
@@ -1,0 +1,229 @@
+import { PriorityQueue, DictionaryExtensionMethods, Utils } from './utils.js';
+import { Goal, ExtremeGoal, ComparativeGoal, ComparisonOperator } from './goals.js';
+import { Action } from './actions.js';
+import { Agent } from './agent.js';
+import { PriorityQueueNode } from './types.js';
+
+export class ActionNode extends PriorityQueueNode {
+  constructor(action, state, parameters) {
+    super();
+    this.action = action ? action.copy() : null;
+    this.state = DictionaryExtensionMethods.copyDict(state);
+    this.parameters = DictionaryExtensionMethods.copyDict(parameters);
+    if (this.action) {
+      this.action.setParameters(this.parameters);
+    }
+  }
+
+  cost(currentState) {
+    if (!this.action) return Infinity;
+    return this.action.getCost(currentState);
+  }
+
+  equals(other) {
+    if (!(other instanceof ActionNode)) return false;
+    if (this === other) return true;
+    if (this.action) {
+      if (!other.action) return false;
+      if (!this.action.equals(other.action)) return false;
+    } else if (other.action) {
+      return false;
+    }
+    return this._stateMatches(other);
+  }
+
+  hashCode() {
+    const actionHash = this.action ? this.action.hashCode() : 0;
+    const items = [];
+    for (const [k, v] of Object.entries(this.state)) {
+      try {
+        const val = typeof v === 'object' ? JSON.stringify(v) : String(v);
+        items.push(`${k}:${val}`);
+      } catch {}
+    }
+    const stateStr = items.sort().join('|');
+    let hash = 0;
+    const str = `${actionHash}|${stateStr}`;
+    for (let i = 0; i < str.length; i++) {
+      hash = ((hash << 5) - hash) + str.charCodeAt(i);
+      hash |= 0;
+    }
+    return hash;
+  }
+
+  _stateMatches(other) {
+    for (const [k, v] of Object.entries(this.state)) {
+      if (!(k in other.state)) return false;
+      if (other.state[k] !== v) return false;
+    }
+    for (const [k, v] of Object.entries(other.state)) {
+      if (!(k in this.state)) return false;
+      if (this.state[k] !== v) return false;
+    }
+    return true;
+  }
+}
+
+export class ActionGraph {
+  constructor(actions, state) {
+    this.actionNodes = [];
+    for (const action of actions) {
+      const permutations = action.getPermutations(state);
+      for (const perm of permutations) {
+        this.actionNodes.push(new ActionNode(action, state, perm));
+      }
+    }
+  }
+
+  *neighbors(node) {
+    for (const template of this.actionNodes) {
+      if (template.action && template.action.isPossible(node.state)) {
+        const newAction = template.action.copy();
+        const newState = DictionaryExtensionMethods.copyDict(node.state);
+        const newParams = DictionaryExtensionMethods.copyDict(template.parameters);
+        const newNode = new ActionNode(newAction, newState, newParams);
+        if (newNode.action) {
+          newNode.action.applyEffects(newNode.state);
+        }
+        yield newNode;
+      }
+    }
+  }
+}
+
+export class ActionAStar {
+  constructor(graph, start, goal, costMax, stepMax) {
+    this.goal = goal;
+    this.finalPoint = null;
+    this.costSoFar = new Map();
+    this.stepsSoFar = new Map();
+    this.cameFrom = new Map();
+
+    const frontier = new PriorityQueue();
+    frontier.enqueue(start, 0);
+    this.cameFrom.set(start, start);
+    this.costSoFar.set(start, 0);
+    this.stepsSoFar.set(start, 0);
+
+    while (frontier.count > 0) {
+      const current = frontier.dequeue();
+      if (this._meetsGoal(current, start)) {
+        this.finalPoint = current;
+        break;
+      }
+      for (const next of graph.neighbors(current)) {
+        const actionCost = next.cost(current.state);
+        const newCost = this.costSoFar.get(current) + actionCost;
+        const newSteps = this.stepsSoFar.get(current) + 1;
+        if (newCost > costMax || newSteps > stepMax) continue;
+        if (!this.costSoFar.has(next) || newCost < this.costSoFar.get(next)) {
+          this.costSoFar.set(next, newCost);
+          this.stepsSoFar.set(next, newSteps);
+          const priority = newCost + this._heuristic(next, goal, current);
+          if (frontier.contains(next)) {
+            frontier.updatePriority(next, priority);
+          } else {
+            frontier.enqueue(next, priority);
+          }
+          this.cameFrom.set(next, current);
+          Agent.onEvaluatedActionNode(next, this.cameFrom);
+        }
+      }
+    }
+  }
+
+  _heuristic(node, goal, prev) {
+    let cost = 0;
+    if (goal instanceof Goal) {
+      for (const [k, v] of Object.entries(goal.desiredState)) {
+        if (!(k in node.state) || node.state[k] !== v) cost += 1;
+      }
+    } else if (goal instanceof ExtremeGoal) {
+      for (const [k, maximize] of Object.entries(goal.desiredState)) {
+        if (!(k in node.state) || !(k in prev.state)) { cost += Infinity; continue; }
+        const cur = node.state[k];
+        const prevVal = prev.state[k];
+        if (maximize) {
+          if (!Utils.isHigherThanOrEquals(cur, prevVal)) cost += Math.abs(cur - prevVal);
+        } else {
+          if (!Utils.isLowerThanOrEquals(cur, prevVal)) cost += Math.abs(cur - prevVal);
+        }
+      }
+    } else if (goal instanceof ComparativeGoal) {
+      for (const [k, pair] of Object.entries(goal.desiredState)) {
+        if (!(k in node.state) || !(k in prev.state)) { cost += Infinity; continue; }
+        const cur = node.state[k];
+        const desired = pair.value;
+        const op = pair.operator;
+        const prevVal = prev.state[k];
+        const diff = Math.abs(cur - prevVal);
+        if (op === ComparisonOperator.Equals) {
+          if (cur !== desired) cost += diff;
+        } else if (op === ComparisonOperator.LessThan) {
+          if (!Utils.isLowerThan(cur, desired)) cost += diff;
+        } else if (op === ComparisonOperator.GreaterThan) {
+          if (!Utils.isHigherThan(cur, desired)) cost += diff;
+        } else if (op === ComparisonOperator.LessThanOrEquals) {
+          if (!Utils.isLowerThanOrEquals(cur, desired)) cost += diff;
+        } else if (op === ComparisonOperator.GreaterThanOrEquals) {
+          if (!Utils.isHigherThanOrEquals(cur, desired)) cost += diff;
+        } else {
+          cost += Infinity;
+        }
+      }
+    }
+    return cost;
+  }
+
+  _meetsGoal(node, prev) {
+    return Utils.meetsGoal(this.goal, node, prev);
+  }
+}
+
+export class Planner {
+  static plan(agent, costMaximum, stepMaximum) {
+    Agent.onPlanningStarted(agent);
+    let bestUtility = 0;
+    let bestAstar = null;
+    let bestGoal = null;
+    for (const goal of agent.goals) {
+      Agent.onPlanningStartedForGoal(agent, goal);
+      const graph = new ActionGraph(agent.actions, agent.state);
+      const startNode = new ActionNode(null, agent.state, {});
+      const astar = new ActionAStar(graph, startNode, goal, costMaximum, stepMaximum);
+      const cursor = astar.finalPoint;
+      if (cursor) {
+        const planCost = astar.costSoFar.get(cursor) || 0;
+        const util = planCost === 0 ? 0 : goal.weight / planCost;
+        if (cursor.action && util > bestUtility) {
+          bestUtility = util;
+          bestAstar = astar;
+          bestGoal = goal;
+        }
+        Agent.onPlanningFinishedForGoal(agent, goal, util);
+      } else {
+        Agent.onPlanningFinishedForGoal(agent, goal, 0);
+      }
+    }
+    if (bestAstar && bestGoal && bestAstar.finalPoint) {
+      Planner._updateAgentActionList(bestAstar.finalPoint, bestAstar, agent);
+      agent.isBusy = true;
+      Agent.onPlanningFinished(agent, bestGoal, bestUtility);
+    } else {
+      Agent.onPlanningFinished(agent, null, 0);
+    }
+    agent.isPlanning = false;
+  }
+
+  static _updateAgentActionList(startNode, astar, agent) {
+    let cursor = startNode;
+    const actionList = [];
+    while (cursor && cursor.action && astar.cameFrom.has(cursor)) {
+      actionList.push(cursor.action);
+      cursor = astar.cameFrom.get(cursor);
+    }
+    actionList.reverse();
+    agent.currentActionSequences.push(actionList);
+    Agent.onPlanUpdated(agent, actionList);
+  }
+}

--- a/rpg-goap-js/src/goap/sensors.js
+++ b/rpg-goap-js/src/goap/sensors.js
@@ -1,0 +1,23 @@
+export class Sensor {
+  static _onSensorRun = [];
+
+  static onSensorRun(agent, sensor) {
+    Sensor._onSensorRun.forEach((h) => h(agent, sensor));
+  }
+
+  static registerOnSensorRun(h) {
+    Sensor._onSensorRun.push(h);
+  }
+
+  constructor(runCallback, name = null) {
+    this.name = name ?? `Sensor`;
+    this._runCallback = runCallback;
+  }
+
+  run(agent) {
+    Sensor.onSensorRun(agent, this);
+    if (this._runCallback) {
+      this._runCallback(agent);
+    }
+  }
+}

--- a/rpg-goap-js/src/goap/types.js
+++ b/rpg-goap-js/src/goap/types.js
@@ -1,0 +1,14 @@
+/**
+ * @typedef {Object.<string, any>} StateDictionary
+ */
+export const StateDictionary = Object;
+
+/**
+ * Base class for nodes stored in PriorityQueue.
+ */
+export class PriorityQueueNode {
+  constructor() {
+    this.priority = 0;
+    this.queueIndex = 0;
+  }
+}

--- a/rpg-goap-js/src/goap/utils.js
+++ b/rpg-goap-js/src/goap/utils.js
@@ -1,0 +1,171 @@
+import { PriorityQueueNode } from './types.js';
+import { Goal, ExtremeGoal, ComparativeGoal, ComparisonOperator } from './goals.js';
+
+/**
+ * Simple priority queue for GOAP algorithms.
+ * Not optimized for huge data sets but sufficient for tests.
+ */
+export class PriorityQueue {
+  constructor() {
+    this._heap = [];
+    this._entryMap = new Map();
+    this._counter = 0;
+  }
+
+  enqueue(item, priority) {
+    if (this._entryMap.has(item)) {
+      const entry = this._entryMap.get(item);
+      entry.removed = true;
+    }
+    const entry = { priority, index: this._counter++, item, removed: false };
+    this._entryMap.set(item, entry);
+    this._heap.push(entry);
+    this._heap.sort((a, b) => a.priority - b.priority || a.index - b.index);
+  }
+
+  dequeue() {
+    while (this._heap.length > 0) {
+      const entry = this._heap.shift();
+      if (!entry.removed) {
+        this._entryMap.delete(entry.item);
+        return entry.item;
+      }
+    }
+    throw new Error('Cannot dequeue from an empty priority queue.');
+  }
+
+  updatePriority(item, newPriority) {
+    this.enqueue(item, newPriority);
+  }
+
+  contains(item) {
+    return this._entryMap.has(item) && !this._entryMap.get(item).removed;
+  }
+
+  get count() {
+    let c = 0;
+    for (const entry of this._heap) {
+      if (!entry.removed) c++;
+    }
+    return c;
+  }
+}
+
+export class DictionaryExtensionMethods {
+  static copyDict(obj) {
+    return { ...obj };
+  }
+
+  static copyConcurrentDict(obj) {
+    return { ...obj };
+  }
+
+  static copyComparisonValuePairDict(obj) {
+    return { ...obj };
+  }
+
+  static copyStringDict(obj) {
+    return { ...obj };
+  }
+
+  static copyNonNullableDict(obj) {
+    return { ...obj };
+  }
+}
+
+export class Utils {
+  static isLowerThan(a, b) {
+    return typeof a === 'number' && typeof b === 'number' ? a < b : false;
+  }
+
+  static isHigherThan(a, b) {
+    return typeof a === 'number' && typeof b === 'number' ? a > b : false;
+  }
+
+  static isLowerThanOrEquals(a, b) {
+    return typeof a === 'number' && typeof b === 'number' ? a <= b : false;
+  }
+
+  static isHigherThanOrEquals(a, b) {
+    return typeof a === 'number' && typeof b === 'number' ? a >= b : false;
+  }
+
+  static meetsGoal(goal, node, prev) {
+    if (goal instanceof Goal) {
+      for (const [k, v] of Object.entries(goal.desiredState)) {
+        if (!(k in node.state)) return false;
+        const cur = node.state[k];
+        if (cur === null && v !== null) return false;
+        if (cur !== null && cur !== v) return false;
+      }
+      return true;
+    } else if (goal instanceof ExtremeGoal) {
+      if (!node.action) return false;
+      for (const [k, maximize] of Object.entries(goal.desiredState)) {
+        if (!(k in node.state) || !(k in prev.state)) return false;
+        const cur = node.state[k];
+        const prevVal = prev.state[k];
+        if (cur == null || prevVal == null) return false;
+        if (maximize) {
+          if (!Utils.isHigherThanOrEquals(cur, prevVal)) return false;
+        } else {
+          if (!Utils.isLowerThanOrEquals(cur, prevVal)) return false;
+        }
+      }
+      return true;
+    } else if (goal instanceof ComparativeGoal) {
+      for (const [k, pair] of Object.entries(goal.desiredState)) {
+        if (!(k in node.state) || !(k in prev.state)) return false;
+        const cur = node.state[k];
+        const desired = pair.value;
+        const op = pair.operator;
+        if (op === ComparisonOperator.Undefined) return false;
+        if (op === ComparisonOperator.Equals && cur !== desired) return false;
+        if (op === ComparisonOperator.LessThan) {
+          if (cur == null || desired == null) return false;
+          if (!Utils.isLowerThan(cur, desired)) return false;
+        } else if (op === ComparisonOperator.GreaterThan) {
+          if (cur == null || desired == null) return false;
+          if (!Utils.isHigherThan(cur, desired)) return false;
+        } else if (op === ComparisonOperator.LessThanOrEquals) {
+          if (cur == null || desired == null) return false;
+          if (!Utils.isLowerThanOrEquals(cur, desired)) return false;
+        } else if (op === ComparisonOperator.GreaterThanOrEquals) {
+          if (cur == null || desired == null) return false;
+          if (!Utils.isHigherThanOrEquals(cur, desired)) return false;
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+}
+
+export class PermutationSelectorGenerators {
+  static selectFromCollection(values) {
+    return (state) => values.filter((v) => v != null);
+  }
+
+  static selectFromCollectionInState(key) {
+    return (state) => {
+      const output = [];
+      const values = state[key];
+      if (Array.isArray(values)) {
+        for (const item of values) {
+          if (item != null) output.push(item);
+        }
+      }
+      return output;
+    };
+  }
+
+  static selectFromIntegerRange(lower, upper) {
+    return (state) => {
+      const out = [];
+      for (let i = lower; i < upper; i++) out.push(i);
+      return out;
+    };
+  }
+}
+
+export { PriorityQueueNode };

--- a/rpg-goap-js/src/rpg/factories.js
+++ b/rpg-goap-js/src/rpg/factories.js
@@ -1,0 +1,421 @@
+import {
+  Action,
+  StepMode,
+  ExecutionStatus,
+} from '../goap/actions.js';
+import {
+  Goal,
+  ComparativeGoal,
+  ExtremeGoal,
+  ComparisonOperator,
+  ComparisonValuePair,
+} from '../goap/goals.js';
+import { Sensor } from '../goap/sensors.js';
+import { Agent } from '../goap/agent.js';
+import {
+  Vector2,
+  RpgUtils,
+  MaxX,
+  MaxY,
+} from './utils.js';
+
+class CommonRpgAgentHandlers {
+  static _rng() {
+    return Math.random();
+  }
+
+  static _getFoodInRange(source, foodPositions, rangeVal) {
+    for (const position of foodPositions) {
+      if (RpgUtils.inDistance(source, position, rangeVal)) {
+        return position;
+      }
+    }
+    return null;
+  }
+
+  static seeEnemiesSensorHandler(agent) {
+    const agents = agent.state.agents;
+    if (Array.isArray(agents)) {
+      const range = agent.state.sight_range ?? 10.0;
+      const enemy = RpgUtils.getEnemyInRange(agent, agents, range);
+      agent.state.canSeeEnemies = enemy !== null;
+    }
+  }
+
+  static enemyProximitySensorHandler(agent) {
+    const agents = agent.state.agents;
+    if (Array.isArray(agents)) {
+      const enemy = RpgUtils.getEnemyInRange(agent, agents, 1.0);
+      agent.state.nearEnemy = enemy !== null;
+    }
+  }
+
+  static killNearbyEnemyExecutor(agent, action) {
+    const agents = agent.state.agents;
+    if (Array.isArray(agents)) {
+      const target = RpgUtils.getEnemyInRange(agent, agents, 1.0);
+      if (target) {
+        const currentHp = target.state.hp;
+        if (typeof currentHp === 'number') {
+          target.state.hp = currentHp - 1;
+          if (target.state.hp <= 0) {
+            return ExecutionStatus.Succeeded;
+          }
+          return ExecutionStatus.Executing;
+        }
+      }
+    }
+    return ExecutionStatus.Failed;
+  }
+
+  static goToEnemyExecutor(agent, action) {
+    const target = action.getParameter('target');
+    const agentPos = agent.state.position;
+    if (!(target instanceof Agent) || !(agentPos instanceof Vector2)) {
+      return ExecutionStatus.Failed;
+    }
+    const targetPos = target.state.position;
+    if (!(targetPos instanceof Vector2)) return ExecutionStatus.Failed;
+    const newPos = RpgUtils.moveTowardsOtherPosition(agentPos, targetPos);
+    agent.state.position = newPos;
+    if (RpgUtils.inDistance(newPos, targetPos, 1.0)) {
+      return ExecutionStatus.Succeeded;
+    }
+    return ExecutionStatus.Executing;
+  }
+
+  static seeFoodSensorHandler(agent) {
+    const agentPos = agent.state.position;
+    const foodPositions = agent.state.foodPositions;
+    if (agentPos instanceof Vector2 && Array.isArray(foodPositions)) {
+      const range = agent.state.food_sight_range ?? 20.0;
+      const food = CommonRpgAgentHandlers._getFoodInRange(
+        agentPos,
+        foodPositions,
+        range
+      );
+      agent.state.canSeeFood = food !== null;
+      if (!agent.state.canSeeFood && agent.state.eatingFood) {
+        agent.state.eatingFood = false;
+      }
+    }
+  }
+
+  static foodProximitySensorHandler(agent) {
+    const agentPos = agent.state.position;
+    const foodPositions = agent.state.foodPositions;
+    if (agentPos instanceof Vector2 && Array.isArray(foodPositions)) {
+      const food = CommonRpgAgentHandlers._getFoodInRange(
+        agentPos,
+        foodPositions,
+        1.0
+      );
+      agent.state.nearFood = food !== null;
+      if (!agent.state.nearFood && agent.state.eatingFood) {
+        agent.state.eatingFood = false;
+      }
+    }
+  }
+
+  static lookForFoodExecutor(agent, action) {
+    const agentPos = agent.state.position;
+    if (agentPos instanceof Vector2) {
+      let newX = agentPos.x + Math.floor(CommonRpgAgentHandlers._rng() * 3) - 1;
+      let newY = agentPos.y + Math.floor(CommonRpgAgentHandlers._rng() * 3) - 1;
+      newX = Math.max(0, Math.min(newX, MaxX - 1));
+      newY = Math.max(0, Math.min(newY, MaxY - 1));
+      agent.state.position = new Vector2(newX, newY);
+    }
+    if (agent.state.canSeeFood === true) {
+      return ExecutionStatus.Succeeded;
+    }
+    return ExecutionStatus.Failed;
+  }
+
+  static goToFoodExecutor(agent, action) {
+    const foodPos = action.getParameter('target');
+    const agentPos = agent.state.position;
+    if (!(foodPos instanceof Vector2) || !(agentPos instanceof Vector2)) {
+      return ExecutionStatus.Failed;
+    }
+    const newPos = RpgUtils.moveTowardsOtherPosition(agentPos, foodPos);
+    agent.state.position = newPos;
+    if (RpgUtils.inDistance(newPos, foodPos, 1.0)) {
+      return ExecutionStatus.Succeeded;
+    }
+    return ExecutionStatus.Executing;
+  }
+
+  static eatFoodExecutor(agent, action) {
+    const foodPositions = agent.state.foodPositions;
+    const agentPos = agent.state.position;
+    if (Array.isArray(foodPositions) && agentPos instanceof Vector2) {
+      const food = CommonRpgAgentHandlers._getFoodInRange(
+        agentPos,
+        foodPositions,
+        1.0
+      );
+      if (food) {
+        const foodEaten = agent.state.food_eaten ?? 0;
+        foodPositions.splice(foodPositions.indexOf(food), 1);
+        agent.state.food_eaten = foodEaten + 1;
+        return ExecutionStatus.Succeeded;
+      }
+    }
+    return ExecutionStatus.Failed;
+  }
+}
+
+export class RpgCharacterFactory {
+  static create(agents, name = 'Player') {
+    const removeEnemiesGoal = new Goal('Remove Enemies', 1.0, {
+      canSeeEnemies: false,
+    });
+
+    const seeEnemiesSensor = new Sensor(
+      CommonRpgAgentHandlers.seeEnemiesSensorHandler,
+      'Enemy Sight Sensor'
+    );
+    const enemyProximitySensor = new Sensor(
+      CommonRpgAgentHandlers.enemyProximitySensorHandler,
+      'Enemy Proximity Sensor'
+    );
+
+    const goToEnemyAction = new Action({
+      name: 'Go To Enemy',
+      executor: CommonRpgAgentHandlers.goToEnemyExecutor,
+      preconditions: { canSeeEnemies: true, nearEnemy: false },
+      postconditions: { nearEnemy: true },
+      permutationSelectors: {
+        target: RpgUtils.enemyPermutations,
+        startingPosition: RpgUtils.startingPositionPermutations,
+      },
+      costCallback: RpgUtils.goToEnemyCost,
+    });
+
+    const killNearbyEnemyAction = new Action({
+      name: 'Kill Nearby Enemy',
+      executor: CommonRpgAgentHandlers.killNearbyEnemyExecutor,
+      preconditions: { nearEnemy: true },
+      postconditions: { canSeeEnemies: false, nearEnemy: false },
+    });
+
+    const agent = new Agent({
+      name,
+      state: {
+        canSeeEnemies: false,
+        nearEnemy: false,
+        hp: 80,
+        position: new Vector2(10, 10),
+        faction: name.includes('Monster') ? 'enemy' : 'player',
+        agents,
+        sight_range: name.includes('Monster') ? 5.0 : 10.0,
+      },
+      goals: [removeEnemiesGoal],
+      sensors: [seeEnemiesSensor, enemyProximitySensor],
+      actions: [goToEnemyAction, killNearbyEnemyAction],
+    });
+
+    return agent;
+  }
+}
+
+export class PlayerFactory {
+  static create(agents, foodPositions, name = 'Player', useExtreme = false) {
+    const foodGoal = useExtreme
+      ? new ExtremeGoal('Maximize Food Eaten', 1.0, { food_eaten: true })
+      : new ComparativeGoal('Get exactly 3 food', 1.0, {
+          food_eaten: new ComparisonValuePair(3, ComparisonOperator.Equals),
+        });
+
+    const removeEnemiesGoal = new Goal('Remove Enemies', 10.0, {
+      canSeeEnemies: false,
+    });
+
+    const seeEnemiesSensor = new Sensor(
+      CommonRpgAgentHandlers.seeEnemiesSensorHandler,
+      'Enemy Sight Sensor'
+    );
+    const enemyProximitySensor = new Sensor(
+      CommonRpgAgentHandlers.enemyProximitySensorHandler,
+      'Enemy Proximity Sensor'
+    );
+    const seeFoodSensor = new Sensor(
+      CommonRpgAgentHandlers.seeFoodSensorHandler,
+      'Food Sight Sensor'
+    );
+    const foodProximitySensor = new Sensor(
+      CommonRpgAgentHandlers.foodProximitySensorHandler,
+      'Food Proximity Sensor'
+    );
+
+    const goToEnemyAction = new Action({
+      name: 'Go To Enemy',
+      executor: CommonRpgAgentHandlers.goToEnemyExecutor,
+      preconditions: { canSeeEnemies: true, nearEnemy: false },
+      postconditions: { nearEnemy: true },
+      permutationSelectors: {
+        target: RpgUtils.enemyPermutations,
+        startingPosition: RpgUtils.startingPositionPermutations,
+      },
+      costCallback: RpgUtils.goToEnemyCost,
+    });
+
+    const killNearbyEnemyAction = new Action({
+      name: 'Kill Nearby Enemy',
+      executor: CommonRpgAgentHandlers.killNearbyEnemyExecutor,
+      preconditions: { nearEnemy: true },
+      postconditions: { canSeeEnemies: false, nearEnemy: false },
+    });
+
+    const lookForFoodAction = new Action({
+      name: 'Look For Food',
+      executor: CommonRpgAgentHandlers.lookForFoodExecutor,
+      preconditions: { canSeeFood: false },
+      postconditions: { canSeeFood: true },
+    });
+
+    const goToFoodAction = new Action({
+      name: 'Go To Food',
+      executor: CommonRpgAgentHandlers.goToFoodExecutor,
+      preconditions: { canSeeFood: true, nearFood: false },
+      postconditions: { nearFood: true },
+      permutationSelectors: {
+        target: RpgUtils.foodPermutations,
+        startingPosition: RpgUtils.startingPositionPermutations,
+      },
+      costCallback: RpgUtils.goToFoodCost,
+    });
+
+    const eatFoodAction = new Action({
+      name: 'Eat Food',
+      executor: CommonRpgAgentHandlers.eatFoodExecutor,
+      preconditions: { nearFood: true },
+      arithmeticPostconditions: { food_eaten: 1 },
+    });
+
+    const restAction = new Action({
+      name: 'Rest',
+      executor: () => ExecutionStatus.Succeeded,
+      preconditions: { well_rested: false },
+      postconditions: { well_rested: true, stretched: false },
+      costCallback: () => 100,
+    });
+
+    const walkAroundAction = new Action({
+      name: 'Walk Around',
+      executor: () => ExecutionStatus.Succeeded,
+      preconditions: { stretched: false },
+      postconditions: { stretched: true, well_rested: false },
+      costCallback: () => 100,
+    });
+
+    const agent = new Agent({
+      name,
+      state: {
+        canSeeEnemies: false,
+        nearEnemy: false,
+        canSeeFood: false,
+        nearFood: false,
+        hp: 80,
+        food_eaten: 0,
+        position: new Vector2(10, 10),
+        faction: 'player',
+        agents,
+        foodPositions,
+        well_rested: false,
+        stretched: false,
+        sight_range: 10.0,
+        food_sight_range: 20.0,
+      },
+      goals: [
+        foodGoal,
+        removeEnemiesGoal,
+        new Goal('Get well rested', 0.11, { well_rested: true }),
+        new Goal('Get stretched', 0.1, { stretched: true }),
+      ],
+      sensors: [
+        seeEnemiesSensor,
+        enemyProximitySensor,
+        seeFoodSensor,
+        foodProximitySensor,
+      ],
+      actions: [
+        goToEnemyAction,
+        killNearbyEnemyAction,
+        lookForFoodAction,
+        goToFoodAction,
+        eatFoodAction,
+        restAction,
+        walkAroundAction,
+      ],
+    });
+
+    return agent;
+  }
+}
+
+export class RpgMonsterFactory {
+  static _counter = 1;
+
+  static create(agents, foodPositions) {
+    const name = `Monster ${RpgMonsterFactory._counter++}`;
+    const agent = RpgCharacterFactory.create(agents, name);
+    agent.state.faction = 'enemy';
+
+    const eatFoodGoal = new Goal('Eat Food', 0.1, { eatingFood: true });
+    const seeFoodSensor = new Sensor(
+      CommonRpgAgentHandlers.seeFoodSensorHandler,
+      'Food Sight Sensor'
+    );
+    const foodProximitySensor = new Sensor(
+      CommonRpgAgentHandlers.foodProximitySensorHandler,
+      'Food Proximity Sensor'
+    );
+
+    const lookForFoodAction = new Action({
+      name: 'Look For Food',
+      executor: CommonRpgAgentHandlers.lookForFoodExecutor,
+      preconditions: { canSeeFood: false, canSeeEnemies: false },
+      postconditions: { canSeeFood: true },
+    });
+
+    const goToFoodAction = new Action({
+      name: 'Go To Food',
+      executor: CommonRpgAgentHandlers.goToFoodExecutor,
+      preconditions: { canSeeFood: true, canSeeEnemies: false },
+      postconditions: { nearFood: true },
+      permutationSelectors: {
+        target: RpgUtils.foodPermutations,
+        startingPosition: RpgUtils.startingPositionPermutations,
+      },
+      costCallback: RpgUtils.goToFoodCost,
+    });
+
+    const eatAction = new Action({
+      name: 'Eat',
+      executor: CommonRpgAgentHandlers.eatFoodExecutor,
+      preconditions: { nearFood: true, canSeeEnemies: false },
+      postconditions: { eatingFood: true },
+    });
+
+    agent.state = {
+      ...agent.state,
+      canSeeFood: false,
+      nearFood: false,
+      eatingFood: false,
+      foodPositions,
+      hp: 2,
+      sight_range: 5.0,
+      food_sight_range: 5.0,
+    };
+
+    agent.goals.push(eatFoodGoal);
+    agent.sensors.push(seeFoodSensor, foodProximitySensor);
+    agent.actions.push(goToFoodAction, lookForFoodAction, eatAction);
+    return agent;
+  }
+}
+
+export { CommonRpgAgentHandlers };
+

--- a/rpg-goap-js/src/rpg/factories.js
+++ b/rpg-goap-js/src/rpg/factories.js
@@ -1,7 +1,6 @@
 import {
   Action,
   StepMode,
-  ExecutionStatus,
 } from '../goap/actions.js';
 import {
   Goal,
@@ -9,6 +8,7 @@ import {
   ExtremeGoal,
   ComparisonOperator,
   ComparisonValuePair,
+  ExecutionStatus,
 } from '../goap/goals.js';
 import { Sensor } from '../goap/sensors.js';
 import { Agent } from '../goap/agent.js';

--- a/rpg-goap-js/src/rpg/utils.js
+++ b/rpg-goap-js/src/rpg/utils.js
@@ -1,0 +1,110 @@
+export const MaxX = 20;
+export const MaxY = 20;
+
+export class Vector2 {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  equals(other) {
+    return other instanceof Vector2 && this.x === other.x && this.y === other.y;
+  }
+}
+
+export class RpgUtils {
+  static inDistance(pos1, pos2, maxDistance) {
+    return RpgUtils._distance(pos1, pos2) <= maxDistance;
+  }
+
+  static getEnemyInRange(source, agents, distance) {
+    for (const agent of agents) {
+      if (agent === source) continue;
+      const sourcePos = source.state.position;
+      const agentPos = agent.state.position;
+      const sourceFaction = source.state.faction;
+      const agentFaction = agent.state.faction;
+      if (
+        sourcePos instanceof Vector2 &&
+        agentPos instanceof Vector2 &&
+        typeof sourceFaction === 'string' &&
+        typeof agentFaction === 'string' &&
+        RpgUtils.inDistance(sourcePos, agentPos, distance) &&
+        sourceFaction !== agentFaction
+      ) {
+        return agent;
+      }
+    }
+    return null;
+  }
+
+  static moveTowardsOtherPosition(pos1, pos2) {
+    const newPos = new Vector2(pos1.x, pos1.y);
+    const xDiff = pos2.x - newPos.x;
+    const yDiff = pos2.y - newPos.y;
+    const xSign = xDiff > 0 ? 1 : xDiff < 0 ? -1 : 0;
+    const ySign = yDiff > 0 ? 1 : yDiff < 0 ? -1 : 0;
+    if (xSign !== 0) {
+      newPos.x += xSign;
+    } else if (ySign !== 0) {
+      newPos.y += ySign;
+    }
+    return newPos;
+  }
+
+  static enemyPermutations(state) {
+    const enemies = [];
+    const agents = state.agents;
+    const agentFaction = state.faction;
+    if (!Array.isArray(agents) || typeof agentFaction !== 'string') {
+      return enemies;
+    }
+    for (const agent of agents) {
+      const faction = agent.state.faction;
+      if (typeof faction === 'string' && faction !== agentFaction) {
+        enemies.push(agent);
+      }
+    }
+    return enemies;
+  }
+
+  static foodPermutations(state) {
+    const foodPositions = [];
+    const positions = state.foodPositions;
+    if (!Array.isArray(positions)) return foodPositions;
+    for (const p of positions) {
+      if (p instanceof Vector2) foodPositions.push(p);
+    }
+    return foodPositions;
+  }
+
+  static startingPositionPermutations(state) {
+    const startingPositions = [];
+    const pos = state.position;
+    if (pos instanceof Vector2) startingPositions.push(pos);
+    return startingPositions;
+  }
+
+  static goToEnemyCost(action) {
+    const start = action.getParameter('startingPosition');
+    const target = action.getParameter('target');
+    if (!(start instanceof Vector2) || !target) return Infinity;
+    const targetPos = target.state.position;
+    if (!(targetPos instanceof Vector2)) return Infinity;
+    return RpgUtils._distance(start, targetPos);
+  }
+
+  static goToFoodCost(action) {
+    const start = action.getParameter('startingPosition');
+    const target = action.getParameter('target');
+    if (!(start instanceof Vector2) || !(target instanceof Vector2)) return Infinity;
+    return RpgUtils._distance(start, target);
+  }
+
+  static _distance(p1, p2) {
+    return Math.sqrt(
+      Math.pow(Math.abs(p2.x - p1.x), 2) + Math.pow(Math.abs(p2.y - p1.y), 2)
+    );
+  }
+}
+

--- a/rpg-goap-js/test/actionNode.test.js
+++ b/rpg-goap-js/test/actionNode.test.js
@@ -1,0 +1,13 @@
+import { test } from 'node:test';
+import assert from 'assert';
+import { Action } from '../src/goap/actions.js';
+import { ActionNode } from '../src/goap/planning.js';
+
+test('ActionNode equality and hash', () => {
+  const a1 = new Action({ name: 'a' });
+  const n1 = new ActionNode(a1, { v: 1 }, {});
+  const a2 = new Action({ name: 'a' });
+  const n2 = new ActionNode(a2, { v: 1 }, {});
+  assert.ok(n1.equals(n2));
+  assert.strictEqual(n1.hashCode(), n2.hashCode());
+});

--- a/rpg-goap-js/test/core.test.js
+++ b/rpg-goap-js/test/core.test.js
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'assert';
+import { Agent } from '../src/goap/agent.js';
+import { Action, StepMode } from '../src/goap/actions.js';
+import { Goal } from '../src/goap/goals.js';
+
+// Simple action that sets state.done = true
+const action = new Action({
+  name: 'finish',
+  executor: (agent, act) => {
+    agent.state.done = true;
+    return 3; // ExecutionStatus.Succeeded
+  },
+  postconditions: { done: true },
+});
+
+const goal = new Goal('done', 1, { done: true });
+
+test('agent executes simple plan', () => {
+  const agent = new Agent({ actions: [action], goals: [goal], state: {} });
+  agent.plan();
+  agent.step(StepMode.AllActions);
+  assert.strictEqual(agent.state.done, true);
+});

--- a/rpg-goap-js/test/planAsync.test.js
+++ b/rpg-goap-js/test/planAsync.test.js
@@ -1,0 +1,12 @@
+import { test } from 'node:test';
+import assert from 'assert';
+import { Agent } from '../src/goap/agent.js';
+
+// Plan async should set planning flag and eventually clear it when done.
+// We just check the flag change immediately.
+
+test('agent planAsync sets isPlanning', () => {
+  const agent = new Agent({});
+  agent.planAsync();
+  assert.strictEqual(agent.isPlanning, true);
+});

--- a/rpg-goap-js/test/priorityQueue.test.js
+++ b/rpg-goap-js/test/priorityQueue.test.js
@@ -1,0 +1,15 @@
+import { test } from "node:test";
+import assert from 'assert';
+import { PriorityQueue, PriorityQueueNode } from '../src/goap/utils.js';
+
+class Node extends PriorityQueueNode {}
+
+test('priority queue ordering', () => {
+  const pq = new PriorityQueue();
+  const a = new Node();
+  const b = new Node();
+  pq.enqueue(a, 2);
+  pq.enqueue(b, 1);
+  assert.strictEqual(pq.dequeue(), b);
+  assert.strictEqual(pq.dequeue(), a);
+});

--- a/rpg-goap-js/test/sensor.test.js
+++ b/rpg-goap-js/test/sensor.test.js
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'assert';
+import { Sensor } from '../src/goap/sensors.js';
+import { Agent } from '../src/goap/agent.js';
+
+test('sensor onSensorRun event fires', () => {
+  let called = false;
+  const sensor = new Sensor(() => {}, 's');
+  Sensor.registerOnSensorRun(() => {
+    called = true;
+  });
+  const agent = new Agent();
+  sensor.run(agent);
+  assert.ok(called);
+});

--- a/rpg-goap-js/test/vector2.test.js
+++ b/rpg-goap-js/test/vector2.test.js
@@ -1,0 +1,11 @@
+import { test } from "node:test";
+import assert from 'assert';
+import { Vector2, RpgUtils } from '../src/rpg/utils.js';
+
+test('Vector2 utilities', () => {
+  const v1 = new Vector2(0, 0);
+  const v2 = new Vector2(1, 0);
+  assert.ok(RpgUtils.inDistance(v1, v2, 1));
+  const moved = RpgUtils.moveTowardsOtherPosition(v1, v2);
+  assert.ok(moved.equals(new Vector2(1, 0)));
+});

--- a/rpg/__init__.py
+++ b/rpg/__init__.py
@@ -1,0 +1,2 @@
+from rpg_goap_python_example.utils import *
+from rpg_goap_python_example.factories import *

--- a/rpg/factories.py
+++ b/rpg/factories.py
@@ -1,0 +1,6 @@
+from goap_python.agent import Agent
+
+class PlayerFactory:
+    @staticmethod
+    def create(agents, food_positions, name="Player", use_extreme=False):
+        return Agent(name=name)

--- a/rpg/utils.py
+++ b/rpg/utils.py
@@ -1,0 +1,148 @@
+import math
+from typing import List, Any, Optional
+
+import goap_python.actions
+import goap_python.agent
+from goap_python.types import StateDictionary
+
+# Aliases for convenience
+Action = goap_python.actions.Action
+Agent = goap_python.agent.Agent
+
+MaxX: int = 20
+MaxY: int = 20
+
+
+class Vector2:
+    def __init__(self, x: float, y: float):
+        self.X = x
+        self.Y = y
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Vector2):
+            return NotImplemented
+        return self.X == other.X and self.Y == other.Y
+
+    def __hash__(self) -> int:
+        return hash((self.X, self.Y))
+
+    def __repr__(self) -> str:
+        return f"Vector2({self.X}, {self.Y})"
+
+
+class RpgUtils:
+    @staticmethod
+    def in_distance(pos1: Vector2, pos2: Vector2, max_distance: float) -> bool:
+        distance = RpgUtils._distance(pos1, pos2)
+        return distance <= max_distance
+
+    @staticmethod
+    def get_enemy_in_range(
+        source: "Agent", agents: List["Agent"], distance: float
+    ) -> Optional["Agent"]:
+        for agent in agents:
+            if agent == source:
+                continue
+            source_pos = source.State.get("position")
+            agent_pos = agent.State.get("position")
+            source_faction = source.State.get("faction")
+            agent_faction = agent.State.get("faction")
+            if (
+                isinstance(source_pos, Vector2)
+                and isinstance(agent_pos, Vector2)
+                and isinstance(source_faction, str)
+                and isinstance(agent_faction, str)
+                and RpgUtils.in_distance(source_pos, agent_pos, distance)
+                and source_faction != agent_faction
+            ):
+                return agent
+        return None
+
+    @staticmethod
+    def move_towards_other_position(pos1: Vector2, pos2: Vector2) -> Vector2:
+        new_pos = Vector2(pos1.X, pos1.Y)
+        x_diff = pos2.X - new_pos.X
+        y_diff = pos2.Y - new_pos.Y
+        x_sign = 0
+        if x_diff > 0:
+            x_sign = 1
+        elif x_diff < 0:
+            x_sign = -1
+        y_sign = 0
+        if y_diff > 0:
+            y_sign = 1
+        elif y_diff < 0:
+            y_sign = -1
+        if x_sign != 0:
+            new_pos.X += x_sign
+        elif y_sign != 0:
+            new_pos.Y += y_sign
+        return new_pos
+
+    @staticmethod
+    def enemy_permutations(state: StateDictionary) -> List[Any]:
+        enemies: List[Any] = []
+        agents_list = state.get("agents")
+        agent_faction = state.get("faction")
+        if (
+            not isinstance(agents_list, list)
+            or not all(isinstance(a, Agent) for a in agents_list)
+            or not isinstance(agent_faction, str)
+        ):
+            return enemies
+        for agent in agents_list:
+            if (
+                isinstance(agent.State.get("faction"), str)
+                and agent.State["faction"] != agent_faction
+            ):
+                enemies.append(agent)
+        return enemies
+
+    @staticmethod
+    def food_permutations(state: StateDictionary) -> List[Any]:
+        food_positions: List[Any] = []
+        source_positions = state.get("foodPositions")
+        if not isinstance(source_positions, list) or not all(
+            isinstance(p, Vector2) for p in source_positions
+        ):
+            return food_positions
+        food_positions.extend(source_positions)
+        return food_positions
+
+    @staticmethod
+    def starting_position_permutations(state: StateDictionary) -> List[Any]:
+        starting_positions: List[Any] = []
+        position = state.get("position")
+        if not isinstance(position, Vector2):
+            return starting_positions
+        starting_positions.append(position)
+        return starting_positions
+
+    @staticmethod
+    def go_to_enemy_cost(action: Action, state: StateDictionary) -> float:
+        starting_position = action.get_parameter("startingPosition")
+        target_agent = action.get_parameter("target")
+        if not isinstance(starting_position, Vector2) or not isinstance(
+            target_agent, Agent
+        ):
+            return float("inf")
+        target_position = target_agent.State.get("position")
+        if not isinstance(target_position, Vector2):
+            return float("inf")
+        return RpgUtils._distance(starting_position, target_position)
+
+    @staticmethod
+    def go_to_food_cost(action: Action, state: StateDictionary) -> float:
+        starting_position = action.get_parameter("startingPosition")
+        target_position = action.get_parameter("target")
+        if not isinstance(starting_position, Vector2) or not isinstance(
+            target_position, Vector2
+        ):
+            return float("inf")
+        return RpgUtils._distance(starting_position, target_position)
+
+    @staticmethod
+    def _distance(pos1: Vector2, pos2: Vector2) -> float:
+        return math.sqrt(
+            math.pow(abs(pos2.X - pos1.X), 2) + math.pow(abs(pos2.Y - pos1.Y), 2)
+        )


### PR DESCRIPTION
## Summary
- add hashCode to Action
- implement equals/hashCode for ActionNode along with state comparison helper
- extend ActionNode from PriorityQueueNode and update imports
- add copyConcurrentDict helper
- cover ActionNode equality in unit tests

## Testing
- `npm test --silent --prefix rpg-goap-js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ad4bff2a48325a1f8e03c5a929e60